### PR TITLE
better support for non-ascii client (using with IME)

### DIFF
--- a/indent.lua
+++ b/indent.lua
@@ -1106,7 +1106,7 @@ if not IndentationLib.revision or revision > IndentationLib.revision then
         if oldFun then
             oldFun(editbox, ...)
         end
-        if enabled[editbox] then
+        if enabled[editbox] and not editbox:IsInIMECompositionMode() then
             dirty[editbox] = GetTime()
         end
     end
@@ -1126,7 +1126,7 @@ if not IndentationLib.revision or revision > IndentationLib.revision then
         if oldFun then
             oldFun(editbox, ...)
         end
-        if enabled[editbox] then
+        if enabled[editbox] and not editbox:IsInIMECompositionMode() then
             local now = GetTime()
             local lastUpdate = dirty[editbox] or now
             if now - lastUpdate > 0.2 then


### PR DESCRIPTION
The editor in WeakAuras and others, dosen't work properly if typing with IME (input method editor). Because there is a temporary phase which triggers OnTextChanged event, but the typed text is not final result. This lib's indent operation will keep the temporary text and the final text together.

There is an API IsInIMECompositionMode() to indicate this state.